### PR TITLE
Fix some links

### DIFF
--- a/contrib.md
+++ b/contrib.md
@@ -13,7 +13,7 @@ request integrated.
 
 The first thing to do is to ensure that you have a working GHTorrent
 environment. To do so, please consult the top level
-[README.md](https://github.com/gousiosg/github-mirror/README.md) file with
+[README.md](https://github.com/gousiosg/github-mirror/blob/master/README.md) file with
 instructions on doing so.
 
 ## TODO list
@@ -28,7 +28,7 @@ Do you have a cool idea that will make GHTorrent 100x (or 0.01x) better? That's
 great!  We look forward to reviewing your pull requests! We however advise you
 to:
 
-1. Read the [open issue list](https://github.com/gousiosg/github-mirror)
+1. Read the [open issue list](https://github.com/gousiosg/github-mirror/issues)
 2. Contact the [GHTorrent mailing list](). The maintainers will help you
 implement your proposed feature as efficiently as possible and make sure
 that it does not conflict with any change currently planned.

--- a/halloffame.md
+++ b/halloffame.md
@@ -61,7 +61,7 @@ Github](https://github.com/gousiosg/ghtorrent.org/blob/master/halloffame.md). Yo
 The following people's contributions of GitHub OAuth API keys has allowed
 the data collection process to catch on with GitHub's 10x growth since the
 GHTorrent project started. If you would like to contribute and API key,
-please follow the process specified [here](raw.html).
+please follow the process specified [here](http://ghtorrent.org/services.html).
 
 [Bram Adams](http://mcis.polymtl.ca/bram.html),
 [Maryi Arciniegas Méndez](http://thechiselgroup.org/members/),


### PR DESCRIPTION
There were a few broken links so I fixed them. The mailing list link in [Contributing to GHTorrent](http://ghtorrent.org/contrib.html) is also broken but I don't know where that is supposed to go. Also another small suggestion would be to add instructions on what to do with the generated api key (i.e. where do I send it?) to the [GHTorrent Services](http://ghtorrent.org/services.html) page.