### PR TITLE
Make navigation URLs absolute

### DIFF
--- a/_includes/themes/twitter/default.html
+++ b/_includes/themes/twitter/default.html
@@ -21,7 +21,7 @@
         <div class="container">
           <a class="brand" href="{{ HOME_PATH }}">{{ site.title }}</a>
           <ul class="nav" role="navigation">
-            <li><a href="docs.html">Docs</a></li>
+            <li><a href="/docs.html">Docs</a></li>
             <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">Downloads<b class="caret"></b></a>
             <ul class="dropdown-menu" role="menu" aria-labelledby="drop1">
@@ -62,8 +62,8 @@
               <li><a
                 href="http://travistorrent.testroots.org">TravisTorrent</a></li>
             </ul></li>
-            <li><a href="halloffame.html">Hall of Fame</a></li>
-            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="/halloffame.html">Hall of Fame</a></li>
+            <li><a href="/faq.html">FAQ</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Some of the navigation links are not absolute which leads to errors when navigating away from [pull request performance reports](http://ghtorrent.org/pullreq-perf/). I made these URLs absolute which should fix the problem.